### PR TITLE
Added Trigram search mixin

### DIFF
--- a/camomilla/views/medias.py
+++ b/camomilla/views/medias.py
@@ -1,5 +1,5 @@
 from .base import BaseModelViewset
-from .mixins import BulkDeleteMixin, GetUserLanguageMixin
+from .mixins import BulkDeleteMixin, GetUserLanguageMixin, TrigramSearchMixin
 from ..parsers import MultipartJsonParser
 
 
@@ -20,7 +20,7 @@ class ParseMimeMixin(object):
         return filter_name, super().parse_qs_value(value)
 
 
-class MediaFolderViewSet(GetUserLanguageMixin, ParseMimeMixin, BaseModelViewset):
+class MediaFolderViewSet(GetUserLanguageMixin, ParseMimeMixin, TrigramSearchMixin, BaseModelViewset):
     model = MediaFolder
     serializer_class = MediaFolderSerializer
     items_per_page = 18
@@ -66,7 +66,7 @@ class MediaFolderViewSet(GetUserLanguageMixin, ParseMimeMixin, BaseModelViewset)
 
 
 class MediaViewSet(
-    GetUserLanguageMixin, BulkDeleteMixin, ParseMimeMixin, BaseModelViewset
+    GetUserLanguageMixin, BulkDeleteMixin, ParseMimeMixin, TrigramSearchMixin, BaseModelViewset
 ):
 
     queryset = Media.objects.all()


### PR DESCRIPTION
This viewset mixin replaces the default search (full text search made by postgresql) with a trigram-distance search made for every field specified in viewset with a default threshold of 0.3 that can be changed in viewset as an attribute. This can be useful when searching into fields which doesn't contain whitespaces (postgresql search vector is based on those), e.g. auto generated filenames for images like `Senzanome.jpg`. For this reason I've also added this mixin into media viewset.