### PR TITLE
feat: add media sourceset renditions improving the performances of me…

### DIFF
--- a/camomilla/models/media.py
+++ b/camomilla/models/media.py
@@ -15,11 +15,16 @@ from django.utils.translation import gettext_lazy as _
 from PIL import Image
 
 from camomilla.fields import JSONField
+from camomilla import settings as camomilla_settings
 from camomilla.settings import THUMBNAIL_FOLDER, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH
 from camomilla.storages.optimize import OptimizedStorage
+from camomilla.storages.rendition import RenditionStorage
+from camomilla.utils.renditions import build_rendition_path, iter_renditions
 import logging
 
 logger = logging.getLogger(__name__)
+
+_renditions_storage = RenditionStorage()
 
 
 class AbstractMediaFolder(models.Model):
@@ -80,6 +85,8 @@ class Media(models.Model):
     size = models.IntegerField(default=0, blank=True, null=True, editable=False)
     mime_type = models.CharField(max_length=128, blank=True, null=True, editable=False)
     image_props = JSONField(default=dict, blank=True, editable=False)
+    renditions = JSONField(default=dict, blank=True, editable=False)
+    renditions_config = JSONField(default=list, blank=True, null=True)
     folder = models.ForeignKey(
         MediaFolder,
         null=True,
@@ -114,6 +121,16 @@ class Media(models.Model):
         self._remove_thumbnail()
         if self.file:
             self._make_thumbnail()
+
+    def get_renditions_config(self):
+        if self.renditions_config:
+            return self.renditions_config
+        return camomilla_settings.MEDIA_RENDITIONS_CONFIG
+
+    def regenerate_renditions(self):
+        self._remove_renditions()
+        self._make_renditions()
+        Media.objects.filter(pk=self.pk).update(renditions=self.renditions)
 
     def get_foreign_fields(self):
         return [
@@ -180,6 +197,49 @@ class Media(models.Model):
         if self.thumbnail:
             self.thumbnail.storage.delete(self.thumbnail.name)
 
+    def _make_renditions(self):
+        if not self.is_image or not camomilla_settings.MEDIA_RENDITIONS_ENABLE:
+            return False
+        try:
+            with self.file.storage.open(self.file.name, "rb") as fh:
+                buf = BytesIO(fh.read())
+            result = {}
+            folder = camomilla_settings.MEDIA_RENDITIONS_FOLDER
+            for cfg, rendition in iter_renditions(buf, self.get_renditions_config()):
+                if rendition is None:
+                    continue
+                path = build_rendition_path(
+                    self.file.name, cfg["name"], rendition["ext"], folder
+                )
+                _renditions_storage.save(path, ContentFile(rendition["bytes"]))
+                result[cfg["name"]] = {
+                    "url": _renditions_storage.url(path),
+                    "path": path,
+                    "width": rendition["width"],
+                    "height": rendition["height"],
+                    "format": rendition["format"],
+                    "size": rendition["size"],
+                }
+            buf.close()
+            self.renditions = result
+            return True
+        except Exception as ex:
+            logger.error("Error generating renditions for %s: %s", self.file.name, ex)
+            return False
+
+    def _remove_renditions(self):
+        if not self.renditions:
+            self.renditions = {}
+            return
+        for entry in list(self.renditions.values()):
+            path = entry.get("path") if isinstance(entry, dict) else None
+            if path:
+                try:
+                    _renditions_storage.delete(path)
+                except Exception as ex:
+                    logger.error("Error deleting rendition %s: %s", path, ex)
+        self.renditions = {}
+
     def _get_file_size(self):
         try:
             return self.file.storage.size(self.file.name)
@@ -197,16 +257,21 @@ def update_media(sender, instance: Media, **kwargs):
     instance._remove_thumbnail()
     image_bytes = instance.file.storage.open(instance.file.name, "rb")
     instance._update_file_info(image_bytes)
+    image_bytes.seek(0)
     instance._make_thumbnail(image_bytes)
+    instance._remove_renditions()
+    instance._make_renditions()
     Media.objects.filter(pk=instance.pk).update(
         size=instance._get_file_size(),
         thumbnail=instance.thumbnail,
         mime_type=instance.mime_type,
         image_props=instance.image_props,
+        renditions=instance.renditions,
     )
 
 
 @receiver(pre_delete, sender=Media, dispatch_uid="make thumbnails")
 def delete_media_files(sender, instance: Media, **kwargs):
+    instance._remove_renditions()
     instance._remove_thumbnail()
     instance._remove_file()

--- a/camomilla/serializers/media.py
+++ b/camomilla/serializers/media.py
@@ -5,11 +5,55 @@ from camomilla.serializers.base import BaseModelSerializer
 from camomilla.storages import OverwriteStorage
 
 
+def _build_renditions_payload(obj, request):
+    if not obj.renditions:
+        return {}
+    payload = {}
+    for name, entry in obj.renditions.items():
+        if not isinstance(entry, dict):
+            continue
+        url = entry.get("url", "")
+        if request is not None and url:
+            url = request.build_absolute_uri(url)
+        payload[name] = {
+            "url": url,
+            "width": entry.get("width"),
+            "height": entry.get("height"),
+            "format": entry.get("format"),
+            "size": entry.get("size"),
+        }
+    return payload
+
+
+def _build_srcset_payload(renditions_payload):
+    by_format = {}
+    for entry in renditions_payload.values():
+        fmt = entry.get("format")
+        width = entry.get("width")
+        url = entry.get("url")
+        if not fmt or not width or not url:
+            continue
+        by_format.setdefault(fmt, []).append((width, url))
+    result = {}
+    for fmt, items in by_format.items():
+        items.sort(key=lambda x: x[0])
+        result[fmt] = ", ".join("{} {}w".format(url, w) for w, url in items)
+    return result
+
+
 class MediaListSerializer(BaseModelSerializer):
     is_image = serializers.SerializerMethodField("get_is_image")
+    renditions = serializers.SerializerMethodField("get_renditions")
+    srcset = serializers.SerializerMethodField("get_srcset")
 
     def get_is_image(self, obj):
         return obj.is_image
+
+    def get_renditions(self, obj):
+        return _build_renditions_payload(obj, self.context.get("request"))
+
+    def get_srcset(self, obj):
+        return _build_srcset_payload(self.get_renditions(obj))
 
     class Meta:
         model = Media
@@ -19,6 +63,8 @@ class MediaListSerializer(BaseModelSerializer):
 class MediaSerializer(BaseModelSerializer):
     links = serializers.SerializerMethodField("get_linked_instances")
     is_image = serializers.SerializerMethodField("get_is_image")
+    renditions = serializers.SerializerMethodField("get_renditions")
+    srcset = serializers.SerializerMethodField("get_srcset")
 
     class Meta:
         model = Media
@@ -53,6 +99,12 @@ class MediaSerializer(BaseModelSerializer):
 
     def get_is_image(self, obj):
         return obj.is_image
+
+    def get_renditions(self, obj):
+        return _build_renditions_payload(obj, self.context.get("request"))
+
+    def get_srcset(self, obj):
+        return _build_srcset_payload(self.get_renditions(obj))
 
 
 class MediaFolderSerializer(BaseModelSerializer):

--- a/camomilla/settings.py
+++ b/camomilla/settings.py
@@ -79,6 +79,46 @@ ENABLE_MEDIA_OPTIMIZATION = pointed_getter(
     django_settings, "CAMOMILLA.MEDIA.OPTIMIZE.ENABLE", True
 )
 
+MEDIA_RENDITIONS_ENABLE = pointed_getter(
+    django_settings, "CAMOMILLA.MEDIA.RENDITIONS.ENABLE", True
+)
+
+MEDIA_RENDITIONS_CONFIG = pointed_getter(
+    django_settings,
+    "CAMOMILLA.MEDIA.RENDITIONS.VARIANTS",
+    [
+        {"name": "sm-webp", "width": 400, "format": "webp"},
+        {"name": "md-webp", "width": 800, "format": "webp"},
+        {"name": "lg-webp", "width": 1600, "format": "webp"},
+        {"name": "sm-avif", "width": 400, "format": "avif"},
+        {"name": "md-avif", "width": 800, "format": "avif"},
+        {"name": "lg-avif", "width": 1600, "format": "avif"},
+        {"name": "sm-original", "width": 400, "format": "original"},
+        {"name": "md-original", "width": 800, "format": "original"},
+        {"name": "lg-original", "width": 1600, "format": "original"},
+    ],
+)
+
+MEDIA_RENDITIONS_FOLDER = pointed_getter(
+    django_settings, "CAMOMILLA.MEDIA.RENDITIONS.FOLDER", "renditions"
+)
+
+MEDIA_RENDITIONS_JPEG_QUALITY = pointed_getter(
+    django_settings, "CAMOMILLA.MEDIA.RENDITIONS.JPEG_QUALITY", 85
+)
+
+MEDIA_RENDITIONS_WEBP_QUALITY = pointed_getter(
+    django_settings, "CAMOMILLA.MEDIA.RENDITIONS.WEBP_QUALITY", 82
+)
+
+MEDIA_RENDITIONS_AVIF_QUALITY = pointed_getter(
+    django_settings, "CAMOMILLA.MEDIA.RENDITIONS.AVIF_QUALITY", 60
+)
+
+MEDIA_RENDITIONS_PREVENT_INFLATE = pointed_getter(
+    django_settings, "CAMOMILLA.MEDIA.RENDITIONS.PREVENT_INFLATE", True
+)
+
 API_NESTING_DEPTH = pointed_getter(django_settings, "CAMOMILLA.API.NESTING_DEPTH", 10)
 
 AUTO_CREATE_HOMEPAGE = pointed_getter(
@@ -119,7 +159,26 @@ DEBUG = pointed_getter(django_settings, "CAMOMILLA.DEBUG", django_settings.DEBUG
 #     },
 #     "MEDIA": {
 #         "OPTIMIZE": {"MAX_WIDTH": 1980, "MAX_HEIGHT": 1400, "DPI": 30, "JPEG_QUALITY": 85, "ENABLE": True},
-#         "THUMBNAIL": {"FOLDER": "", "WIDTH": 50, "HEIGHT": 50}
+#         "THUMBNAIL": {"FOLDER": "", "WIDTH": 50, "HEIGHT": 50},
+#         "RENDITIONS": {
+#             "ENABLE": True,
+#             "FOLDER": "renditions",
+#             "VARIANTS": [
+#                 {"name": "sm-webp", "width": 400, "format": "webp"},
+#                 {"name": "md-webp", "width": 800, "format": "webp"},
+#                 {"name": "lg-webp", "width": 1600, "format": "webp"},
+#                 {"name": "sm-avif", "width": 400, "format": "avif"},
+#                 {"name": "md-avif", "width": 800, "format": "avif"},
+#                 {"name": "lg-avif", "width": 1600, "format": "avif"},
+#                 {"name": "sm-original", "width": 400, "format": "original"},
+#                 {"name": "md-original", "width": 800, "format": "original"},
+#                 {"name": "lg-original", "width": 1600, "format": "original"},
+#             ],
+#             "JPEG_QUALITY": 85,
+#             "WEBP_QUALITY": 82,
+#             "AVIF_QUALITY": 60,
+#             "PREVENT_INFLATE": True,
+#         },
 #     },
 #     "RENDER": {
 #         "TEMPLATE_CONTEXT_FILES": [],

--- a/camomilla/storages/__init__.py
+++ b/camomilla/storages/__init__.py
@@ -1,4 +1,5 @@
 from .optimize import OptimizedStorage
 from .overwrite import OverwriteStorage
+from .rendition import RenditionStorage
 
-__all__ = ["OptimizedStorage", "OverwriteStorage"]
+__all__ = ["OptimizedStorage", "OverwriteStorage", "RenditionStorage"]

--- a/camomilla/storages/rendition.py
+++ b/camomilla/storages/rendition.py
@@ -1,0 +1,11 @@
+from camomilla.storages.default import get_default_storage_class
+
+
+class RenditionStorage(get_default_storage_class()):
+    def _save(self, name, content):
+        if self.exists(name):
+            self.delete(name)
+        return super(RenditionStorage, self)._save(name, content)
+
+    def get_available_name(self, name, *args, **kwargs):
+        return name

--- a/camomilla/templatetags/media_extras.py
+++ b/camomilla/templatetags/media_extras.py
@@ -1,0 +1,134 @@
+from django import template
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+def _renditions(media):
+    renditions = getattr(media, "renditions", None) or {}
+    if not isinstance(renditions, dict):
+        return {}
+    return renditions
+
+
+def _by_format(media):
+    grouped = {}
+    for entry in _renditions(media).values():
+        if not isinstance(entry, dict):
+            continue
+        fmt = entry.get("format")
+        width = entry.get("width")
+        url = entry.get("url")
+        if not fmt or not width or not url:
+            continue
+        grouped.setdefault(fmt, []).append((width, url))
+    for fmt in grouped:
+        grouped[fmt].sort(key=lambda x: x[0])
+    return grouped
+
+
+@register.filter(name="srcset")
+def media_srcset(media, format_name="webp"):
+    """
+    Build a `srcset` string for the given format from a Media instance.
+
+    URLs are whatever is stored on `media.renditions[name].url` — typically
+    storage-relative. For same-origin server-side rendering this is fine;
+    cross-origin callers should use the DRF serializer's absolute URLs.
+    """
+    if not media:
+        return ""
+    grouped = _by_format(media)
+    items = grouped.get(format_name)
+    if not items:
+        return ""
+    return ", ".join("{} {}w".format(url, width) for width, url in items)
+
+
+@register.simple_tag(name="media_srcset_url")
+def media_srcset_url(media, rendition_name):
+    if not media:
+        return ""
+    entry = _renditions(media).get(rendition_name)
+    if not isinstance(entry, dict):
+        return ""
+    return entry.get("url", "")
+
+
+def _fallback_src(media, grouped, fallback_format):
+    items = grouped.get(fallback_format) or grouped.get("original")
+    if items:
+        return items[-1][1]
+    for fmt_items in grouped.values():
+        if fmt_items:
+            return fmt_items[-1][1]
+    if getattr(media, "file", None):
+        try:
+            return media.file.url
+        except Exception:
+            return ""
+    return ""
+
+
+@register.simple_tag(name="media_picture")
+def media_picture(
+    media,
+    alt=None,
+    sizes=None,
+    formats=None,
+    fallback="original",
+    **attrs,
+):
+    if not media:
+        return ""
+    formats = formats or ["avif", "webp"]
+    grouped = _by_format(media)
+    alt_text = alt if alt is not None else (getattr(media, "alt_text", "") or "")
+
+    img_src = _fallback_src(media, grouped, fallback)
+
+    if not grouped:
+        img_attrs = {"src": img_src, "alt": alt_text, **attrs}
+        return mark_safe(
+            "<img {}>".format(
+                " ".join(
+                    '{}="{}"'.format(k, escape(v)) for k, v in img_attrs.items() if v is not None
+                )
+            )
+        )
+
+    source_mime = {
+        "avif": "image/avif",
+        "webp": "image/webp",
+        "jpeg": "image/jpeg",
+        "png": "image/png",
+    }
+    sources = []
+    for fmt in formats:
+        items = grouped.get(fmt)
+        if not items:
+            continue
+        srcset = ", ".join("{} {}w".format(url, w) for w, url in items)
+        parts = [
+            'type="{}"'.format(source_mime.get(fmt, "image/" + fmt)),
+            'srcset="{}"'.format(escape(srcset)),
+        ]
+        if sizes:
+            parts.append('sizes="{}"'.format(escape(sizes)))
+        sources.append("<source {}>".format(" ".join(parts)))
+
+    img_attrs = {"src": img_src, "alt": alt_text}
+    if sizes:
+        img_attrs["sizes"] = sizes
+    img_attrs.update(attrs)
+    img_tag = "<img {}>".format(
+        " ".join(
+            '{}="{}"'.format(k, escape(v)) for k, v in img_attrs.items() if v is not None
+        )
+    )
+
+    return mark_safe("<picture>{sources}{img}</picture>".format(
+        sources="".join(sources),
+        img=img_tag,
+    ))

--- a/camomilla/theme/admin/__init__.py
+++ b/camomilla/theme/admin/__init__.py
@@ -56,6 +56,7 @@ class MediaAdmin(TranslationAwareModelAdmin):
         "thumbnail",
         "size",
         "image_props",
+        "renditions",
     )
     readonly_fields = ("image_preview", "image_thumb_preview", "mime_type")
     list_display = (

--- a/camomilla/utils/renditions.py
+++ b/camomilla/utils/renditions.py
@@ -1,0 +1,140 @@
+import logging
+import os
+from io import BytesIO
+
+from PIL import Image
+
+from camomilla import settings
+
+logger = logging.getLogger(__name__)
+
+try:
+    import pillow_avif  # noqa: F401
+
+    AVIF_AVAILABLE = True
+except ImportError:
+    AVIF_AVAILABLE = False
+
+FORMAT_TABLE = {
+    "webp": ("WEBP", "webp"),
+    "avif": ("AVIF", "avif"),
+    "jpeg": ("JPEG", "jpg"),
+    "jpg": ("JPEG", "jpg"),
+    "png": ("PNG", "png"),
+}
+
+PIL_TO_NAME = {
+    "WEBP": "webp",
+    "AVIF": "avif",
+    "JPEG": "jpeg",
+    "PNG": "png",
+    "GIF": "gif",
+}
+
+
+def resolve_format(rendition_cfg, source_pil_format):
+    fmt = (rendition_cfg.get("format") or "original").lower()
+    if fmt == "original":
+        source_name = PIL_TO_NAME.get(
+            (source_pil_format or "JPEG").upper(), "jpeg"
+        )
+        pil_format, ext = FORMAT_TABLE.get(source_name, ("JPEG", "jpg"))
+        save_kwargs = {"optimize": True}
+        if pil_format == "JPEG":
+            save_kwargs["quality"] = settings.MEDIA_RENDITIONS_JPEG_QUALITY
+        return pil_format, ext, save_kwargs, source_name
+
+    if fmt not in FORMAT_TABLE:
+        return None, None, None, None
+
+    pil_format, ext = FORMAT_TABLE[fmt]
+    save_kwargs = {"optimize": True}
+    if pil_format == "JPEG":
+        save_kwargs["quality"] = settings.MEDIA_RENDITIONS_JPEG_QUALITY
+    elif pil_format == "WEBP":
+        save_kwargs["quality"] = settings.MEDIA_RENDITIONS_WEBP_QUALITY
+    elif pil_format == "AVIF":
+        save_kwargs["quality"] = settings.MEDIA_RENDITIONS_AVIF_QUALITY
+    return pil_format, ext, save_kwargs, fmt
+
+
+def build_rendition_path(original_name, rendition_name, extension, folder):
+    stem = os.path.splitext(os.path.basename(original_name))[0]
+    return "{folder}/{stem}/{name}.{ext}".format(
+        folder=folder.strip("/"),
+        stem=stem,
+        name=rendition_name,
+        ext=extension,
+    )
+
+
+def generate_rendition(pil_image, cfg, source_pil_format, original_size):
+    target_width = int(cfg.get("width") or 0)
+    if target_width <= 0:
+        return None
+
+    if target_width >= pil_image.width:
+        return None
+
+    pil_format, ext, save_kwargs, fmt_name = resolve_format(cfg, source_pil_format)
+    if pil_format is None:
+        return None
+
+    if pil_format == "AVIF" and not AVIF_AVAILABLE:
+        return None
+
+    ratio = target_width / pil_image.width
+    target_height = max(1, int(round(pil_image.height * ratio)))
+
+    image = pil_image.copy()
+    image = image.resize((target_width, target_height), Image.LANCZOS)
+
+    if pil_format in ("JPEG",) and image.mode in ("RGBA", "P"):
+        image = image.convert("RGB")
+
+    tmp = BytesIO()
+    try:
+        image.save(tmp, pil_format, **save_kwargs)
+    except Exception as e:
+        logger.error(
+            "Error saving rendition %s as %s: %s", cfg.get("name"), pil_format, e
+        )
+        tmp.close()
+        return None
+
+    data = tmp.getvalue()
+    tmp.close()
+
+    if (
+        settings.MEDIA_RENDITIONS_PREVENT_INFLATE
+        and original_size
+        and len(data) > original_size
+    ):
+        return None
+
+    return {
+        "bytes": data,
+        "width": target_width,
+        "height": target_height,
+        "format": fmt_name,
+        "ext": ext,
+        "size": len(data),
+    }
+
+
+def iter_renditions(image_bytes, config):
+    image_bytes.seek(0)
+    with Image.open(image_bytes) as source:
+        source.load()
+        source_format = source.format
+        original_size = 0
+        try:
+            image_bytes.seek(0, os.SEEK_END)
+            original_size = image_bytes.tell()
+            image_bytes.seek(0)
+        except Exception:
+            original_size = 0
+
+        for cfg in config or []:
+            result = generate_rendition(source, cfg, source_format, original_size)
+            yield cfg, result

--- a/camomilla/views/medias.py
+++ b/camomilla/views/medias.py
@@ -1,3 +1,4 @@
+from rest_framework.decorators import action
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 
@@ -73,3 +74,10 @@ class MediaViewSet(
     serializer_class = MediaSerializer
     model = Media
     parser_classes = [MultipartJsonParser, JSONParser]
+
+    @action(detail=True, methods=["post"], url_path="regenerate-renditions")
+    def regenerate_renditions(self, request, pk=None):
+        instance = self.get_object()
+        instance.regenerate_renditions()
+        instance.refresh_from_db()
+        return Response(self.get_serializer(instance).data)

--- a/docs/How to/Use Media/README.md
+++ b/docs/How to/Use Media/README.md
@@ -38,6 +38,151 @@ CAMOMILLA = {
 }
 ```
 
+## 📐 Responsive Renditions (srcset)
+
+In addition to the single optimized original and the thumbnail, Camomilla can generate a configurable set of **responsive image renditions** — width-based, multi-format variants ready to be dropped into an `<img srcset>` or `<picture>` tag. Renditions are produced on upload (and on demand), stored next to the original, and exposed via the REST API in a shape a frontend can consume without any extra processing.
+
+### Default configuration
+
+Out of the box, every uploaded image produces **9 renditions** (3 widths × 3 formats):
+
+| Name | Width | Format |
+|---|---|---|
+| `sm-webp`, `md-webp`, `lg-webp` | 400 / 800 / 1600 | WebP |
+| `sm-avif`, `md-avif`, `lg-avif` | 400 / 800 / 1600 | AVIF |
+| `sm-original`, `md-original`, `lg-original` | 400 / 800 / 1600 | source format (JPEG/PNG) |
+
+Renditions that would upscale the original (target width ≥ source width) are skipped. Renditions whose encoded output is larger than the source are also skipped (inflate guard).
+
+> [!NOTE]
+> AVIF requires the optional `pillow-avif-plugin` dependency. Without it, AVIF renditions are silently omitted — all other formats still generate. Install with `pip install "django-camomilla-cms[avif]"`.
+
+### Settings
+
+All rendition settings live under `CAMOMILLA.MEDIA.RENDITIONS`:
+
+```python
+CAMOMILLA = {
+    "MEDIA": {
+        "RENDITIONS": {
+            "ENABLE": True,
+            "FOLDER": "renditions",
+            "VARIANTS": [
+                {"name": "sm-webp", "width": 400, "format": "webp"},
+                {"name": "md-webp", "width": 800, "format": "webp"},
+                {"name": "lg-webp", "width": 1600, "format": "webp"},
+                {"name": "sm-avif", "width": 400, "format": "avif"},
+                {"name": "md-avif", "width": 800, "format": "avif"},
+                {"name": "lg-avif", "width": 1600, "format": "avif"},
+                {"name": "sm-original", "width": 400, "format": "original"},
+                {"name": "md-original", "width": 800, "format": "original"},
+                {"name": "lg-original", "width": 1600, "format": "original"},
+            ],
+            "JPEG_QUALITY": 85,
+            "WEBP_QUALITY": 82,
+            "AVIF_QUALITY": 60,
+            "PREVENT_INFLATE": True,
+        },
+    },
+}
+```
+
+- **`ENABLE`** — master kill switch. When `False`, no renditions are generated and `media.renditions` stays `{}`.
+- **`VARIANTS`** — list of `{name, width, format}` dicts. `format` accepts `"webp"`, `"avif"`, `"jpeg"`, `"png"`, or `"original"` (keep the source format).
+- **`FOLDER`** — subfolder of `MEDIA_ROOT` where rendition files live. Each original gets its own directory: `renditions/<stem>/<name>.<ext>`.
+- **`PREVENT_INFLATE`** — when `True`, renditions larger than the original are discarded.
+
+### Per-instance override
+
+A single Media can opt into a custom rendition set via the `renditions_config` field (JSON list, same schema as the global `VARIANTS`). Set it to `null` or an empty list to fall back to the global config.
+
+```python
+media = Media.objects.get(pk=1)
+media.renditions_config = [
+    {"name": "tiny", "width": 100, "format": "webp"},
+    {"name": "square", "width": 600, "format": "webp"},
+]
+media.save()
+media.regenerate_renditions()
+```
+
+### API response shape
+
+`GET /api/camomilla/media/<id>/` now returns two extra fields, `renditions` and `srcset`:
+
+```json
+{
+    "id": 6,
+    "file": "http://mydomain.it/media/sample-image.jpg",
+    "thumbnail": "http://mydomain.it/media/thumbnails/sample-image_thumb.jpg",
+    "mime_type": "image/jpeg",
+    "image_props": {"mode": "RGB", "width": 1980, "format": "JPEG", "height": 1319},
+    "renditions": {
+        "sm-webp": {
+            "url": "http://mydomain.it/media/renditions/sample-image/sm-webp.webp",
+            "width": 400, "height": 267, "format": "webp", "size": 18432
+        },
+        "md-webp": {"url": "...", "width": 800, "height": 533, "format": "webp", "size": 52111},
+        "lg-webp": {"url": "...", "width": 1600, "height": 1066, "format": "webp", "size": 180032}
+    },
+    "srcset": {
+        "webp":     "http://.../sm-webp.webp 400w, http://.../md-webp.webp 800w, http://.../lg-webp.webp 1600w",
+        "avif":     "http://.../sm-avif.avif 400w, ...",
+        "original": "http://.../sm-original.jpg 400w, ..."
+    },
+    "renditions_config": null
+}
+```
+
+- **`renditions`** — map keyed by variant name. Each entry has a fully qualified `url`, plus `width`, `height`, `format`, and `size` in bytes. The internal storage `path` is omitted from API output.
+- **`srcset`** — convenience map keyed by format, with values already formatted as `"url WIDTHw, url WIDTHw, ..."`. Drop the string straight into a `<source srcset>` attribute.
+
+### Using renditions in a frontend
+
+Build a `<picture>` tag directly from the `srcset` payload:
+
+```html
+<picture>
+  <source type="image/avif" srcset="{media.srcset.avif}" sizes="(min-width: 1024px) 1600px, 100vw">
+  <source type="image/webp" srcset="{media.srcset.webp}" sizes="(min-width: 1024px) 1600px, 100vw">
+  <img src="{media.file}" srcset="{media.srcset.original}" alt="{media.alt_text}" loading="lazy">
+</picture>
+```
+
+If you use Astro, the [Astro Camomilla Integration](../Use%20Astro%20Integration/) ships a ready-made `<CamomillaPicture>` component that consumes this shape directly.
+
+### Regeneration endpoint
+
+Force-regenerate all renditions for a single Media (useful after changing `renditions_config` or after bulk-editing the global `VARIANTS`):
+
+__URL:__ `/api/camomilla/media/<media_id>/regenerate-renditions/` __METHOD:__ `POST`
+
+The response is the freshly re-serialized Media payload.
+
+### Template tags
+
+For server-rendered Django templates, `camomilla` ships a `media_extras` library:
+
+```django
+{% load media_extras %}
+
+{# Single srcset string #}
+<img src="{{ media.file.url }}"
+     srcset="{{ media|srcset:'webp' }}"
+     sizes="(min-width: 1024px) 1600px, 100vw"
+     alt="{{ media.alt_text }}">
+
+{# Full <picture> element #}
+{% media_picture media alt="Hero image" sizes="(min-width: 1024px) 1600px, 100vw" class="hero-img" loading="lazy" %}
+
+{# Single rendition URL #}
+<img src="{% media_srcset_url media 'md-webp' %}">
+```
+
+- **`|srcset:'<format>'`** — filter returning a comma-joined `srcset` string for the given format. Empty string on non-images.
+- **`{% media_picture %}`** — renders a full `<picture>` with AVIF/WebP sources + fallback `<img>`. Extra kwargs (`class`, `loading`, `decoding`, `width`, `height`, …) pass through to the `<img>`. Degrades to a bare `<img>` when no renditions exist.
+- **`{% media_srcset_url %}`** — returns a single rendition's URL by name.
+
 
 ## 🗂️ Media API
 
@@ -98,9 +243,18 @@ __Response:__
         "format": "JPEG",
         "height": 1319
     },
+    "renditions": {
+        "sm-webp": {"url": "...", "width": 400, "height": 267, "format": "webp", "size": 18432}
+    },
+    "srcset": {
+        "webp": "http://.../sm-webp.webp 400w, http://.../md-webp.webp 800w, http://.../lg-webp.webp 1600w"
+    },
+    "renditions_config": null,
     "folder": null
 }
 ```
+
+See [Responsive Renditions](#-responsive-renditions-srcset) above for the full schema and configuration.
 
 ### Navigate media folders
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ keywords = ["cms", "django", "api cms"]
 license = {text = "MIT"}
 name = "django-camomilla-cms"
 requires-python = ">= 3.10, <3.15"
+
+[project.optional-dependencies]
+avif = ["pillow-avif-plugin>=1.4"]
+
 [dependency-groups]
 dev = [
   "coverage>=7.10",

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,12 +1,29 @@
 import pytest
 import json
+import os
+from unittest import mock
+from django.conf import settings as django_settings
+from django.template import Context, Template
 from django.test import TransactionTestCase
+from camomilla import settings as camomilla_settings
 from camomilla.models import Media
 from .utils.api import login_superuser
 from .utils.media import load_asset_and_remove_media
 from rest_framework.test import APIClient
 
 client = APIClient()
+
+
+def _clean_renditions_dir():
+    folder = os.path.join(
+        django_settings.MEDIA_ROOT, camomilla_settings.MEDIA_RENDITIONS_FOLDER
+    )
+    if os.path.isdir(folder):
+        for root, dirs, files in os.walk(folder, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
 
 
 class MediaTestCase(TransactionTestCase):
@@ -196,3 +213,132 @@ class MediaTestCase(TransactionTestCase):
         assert Media.objects.count() == 1
         media = Media.objects.first()
         assert media.file.size < asset_size
+
+
+class MediaRenditionsTestCase(TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self):
+        self.client = APIClient()
+        token = login_superuser()
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        _clean_renditions_dir()
+
+    def tearDown(self):
+        _clean_renditions_dir()
+
+    def _upload(self, filename="37059501.png"):
+        asset = load_asset_and_remove_media(filename)
+        response = self.client.post(
+            "/api/camomilla/media/",
+            {
+                "file": asset,
+                "data": json.dumps(
+                    {"translations": {"en": {"alt_text": "x", "title": "x"}}}
+                ),
+            },
+            format="multipart",
+        )
+        assert response.status_code == 201, response.content
+        return Media.objects.get(pk=response.json()["id"])
+
+    def test_renditions_generated_on_upload(self):
+        media = self._upload("37059501.png")
+        assert isinstance(media.renditions, dict)
+        assert "sm-webp" in media.renditions
+        assert "md-webp" in media.renditions
+        sm = media.renditions["sm-webp"]
+        assert sm["width"] == 400
+        assert sm["format"] == "webp"
+        assert sm["size"] > 0
+        assert "url" in sm and "path" in sm
+        full_path = os.path.join(django_settings.MEDIA_ROOT, sm["path"])
+        assert os.path.exists(full_path)
+
+    def test_renditions_skip_upscaling(self):
+        media = self._upload("10595073.png")
+        assert "sm-webp" in media.renditions
+        assert "md-webp" not in media.renditions
+        assert "lg-webp" not in media.renditions
+
+    def test_renditions_wiped_on_delete(self):
+        media = self._upload("37059501.png")
+        paths = [
+            os.path.join(django_settings.MEDIA_ROOT, e["path"])
+            for e in media.renditions.values()
+        ]
+        assert paths and all(os.path.exists(p) for p in paths)
+        pk = media.pk
+        self.client.delete(f"/api/camomilla/media/{pk}/")
+        assert not any(os.path.exists(p) for p in paths)
+
+    def test_regenerate_endpoint(self):
+        media = self._upload("37059501.png")
+        sm_path = os.path.join(
+            django_settings.MEDIA_ROOT, media.renditions["sm-webp"]["path"]
+        )
+        os.remove(sm_path)
+        assert not os.path.exists(sm_path)
+        response = self.client.post(
+            f"/api/camomilla/media/{media.pk}/regenerate-renditions/"
+        )
+        assert response.status_code == 200, response.content
+        assert os.path.exists(sm_path)
+        assert "sm-webp" in response.json()["renditions"]
+
+    def test_per_instance_config_override(self):
+        media = self._upload("37059501.png")
+        media.renditions_config = [
+            {"name": "tiny", "width": 100, "format": "webp"}
+        ]
+        media.save()
+        media.refresh_from_db()
+        media.regenerate_renditions()
+        media.refresh_from_db()
+        assert list(media.renditions.keys()) == ["tiny"]
+        assert media.renditions["tiny"]["width"] == 100
+
+    def test_srcset_field_shape(self):
+        media = self._upload("37059501.png")
+        response = self.client.get(f"/api/camomilla/media/{media.pk}/")
+        assert response.status_code == 200
+        data = response.json()
+        assert "renditions" in data
+        assert "srcset" in data
+        assert isinstance(data["srcset"], dict)
+        assert "webp" in data["srcset"]
+        assert "400w" in data["srcset"]["webp"]
+
+    def test_renditions_disabled_via_setting(self):
+        with mock.patch.object(camomilla_settings, "MEDIA_RENDITIONS_ENABLE", False):
+            media = self._upload("37059501.png")
+            assert media.renditions == {}
+
+    def test_template_tag_srcset_filter(self):
+        media = self._upload("37059501.png")
+        tpl = Template("{% load media_extras %}{{ media|srcset:'webp' }}")
+        rendered = tpl.render(Context({"media": media}))
+        assert "400w" in rendered
+        assert "800w" in rendered
+
+    def test_template_tag_picture(self):
+        media = self._upload("37059501.png")
+        tpl = Template(
+            '{% load media_extras %}{% media_picture media alt="x" %}'
+        )
+        rendered = tpl.render(Context({"media": media}))
+        assert "<picture>" in rendered
+        assert 'type="image/webp"' in rendered
+        assert '<img ' in rendered
+        assert 'alt="x"' in rendered
+
+    def test_template_tag_picture_degrades(self):
+        media = self._upload("37059501.png")
+        Media.objects.filter(pk=media.pk).update(renditions={})
+        media.refresh_from_db()
+        tpl = Template(
+            '{% load media_extras %}{% media_picture media alt="x" %}'
+        )
+        rendered = tpl.render(Context({"media": media}))
+        assert "<picture>" not in rendered
+        assert "<img " in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -378,6 +378,11 @@ dependencies = [
     { name = "uritemplate" },
 ]
 
+[package.optional-dependencies]
+avif = [
+    { name = "pillow-avif-plugin" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "black" },
@@ -406,11 +411,13 @@ requires-dist = [
     { name = "djsuperadmin", specifier = ">=0.11,<1.0.0" },
     { name = "inflection", specifier = ">=0.5.1" },
     { name = "pillow", specifier = ">=9.1.0,<12.0.0" },
+    { name = "pillow-avif-plugin", marker = "extra == 'avif'", specifier = ">=1.4" },
     { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-core", specifier = ">=2.27.0" },
     { name = "python-magic", specifier = ">=0.4,<0.5" },
     { name = "uritemplate", specifier = ">=4.2.0" },
 ]
+provides-extras = ["avif"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -915,6 +922,77 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170 },
     { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505 },
     { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598 },
+]
+
+[[package]]
+name = "pillow-avif-plugin"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/45/c779c020c0972a771778544acd1a1ee0bce83e51f4d2f5f1bda5d53bd373/pillow_avif_plugin-1.5.5.tar.gz", hash = "sha256:e97956a62fc4f252e2a54644312839e194ec09b693f2f7b4d28c44cd747baf9d", size = 20660 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/8f/eaf90299886f708e3da919c3b955b338a614a46e5140083d88fae25f7557/pillow_avif_plugin-1.5.5-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:f000cc51d07d6f47a5b0b2c7f4be0d82af0e1150dcb6361ce8e8973240e8c53a", size = 5158605 },
+    { url = "https://files.pythonhosted.org/packages/c2/7f/d9527b3100c683d36e869b13664efe174720aa9511a074a92232254bff31/pillow_avif_plugin-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f252620a6f96cb127a509df42a304500e2aaec8ced103d448504a1e17439bcb", size = 3817410 },
+    { url = "https://files.pythonhosted.org/packages/da/8d/01e7e59c7af417fb7cf7ee1188b675bd6fadfd6eb606ac23c3761676aa6d/pillow_avif_plugin-1.5.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:00053c630c65d7634a5ac9f42f6981275aed60c4fc41fc5afe9e63178c69f281", size = 4043256 },
+    { url = "https://files.pythonhosted.org/packages/86/90/1f2c866014731681708d9ff74c8215b5a450958934e2429ef9070507eefa/pillow_avif_plugin-1.5.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b9ff99e112bcb54c78481223d476941c3638eda8a243d460d62f72aed2381182", size = 7684794 },
+    { url = "https://files.pythonhosted.org/packages/6a/67/ce9db7fb2559c8c128085fff77ff6d6b38ec8781a91caec808f55227d317/pillow_avif_plugin-1.5.5-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:e3c85a268297bf9de04848ef22003c6d6a9b715a196f467de65c3c92315c60e9", size = 4057330 },
+    { url = "https://files.pythonhosted.org/packages/ae/f4/6cd0439d1a66ae19fe86bf6b2304abbc1fbebdaa980f92d6052c9b3b7281/pillow_avif_plugin-1.5.5-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ed1253bad7a2924164a078341a98384ba1aed08d9d25b59b957438fcac1ac26a", size = 5509943 },
+    { url = "https://files.pythonhosted.org/packages/cc/c6/78f3da85b3119bba53002727d9db25a5cc4c50aa0b99bbbc3731f745cfd6/pillow_avif_plugin-1.5.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:283d2850b2f9ceb6492a6b77ef97fcb07242a31951c61134df0817f6deb29aea", size = 4376981 },
+    { url = "https://files.pythonhosted.org/packages/76/17/87d5d4367e1add83f79fe0bf3706cf4349d0ee0810e802211210fc3db55c/pillow_avif_plugin-1.5.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9814c13ebdbf73cec42db8646d717ca705e50d8994ab9ab42dfaa8a55d6206e9", size = 5757372 },
+    { url = "https://files.pythonhosted.org/packages/a6/30/953ff59b23bb6d07bced57be10e62f1540998200a5dd48f631d7e499ad4a/pillow_avif_plugin-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c259e75cb8ab93b64f2689a580653b20acc48ff393a5aad7731f00a06ad987b1", size = 9875020 },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/5ec1586e95e9acd141414e942b763337081298a3386d1082e8be54d1f9d1/pillow_avif_plugin-1.5.5-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:a34e3f3fe6b50114fa24b001b73644b48f2953cc16522c4703790766d2ef5bc3", size = 5158482 },
+    { url = "https://files.pythonhosted.org/packages/c2/17/57a4962e3178f21285365e3ac96870abb69418df1d9e2cc89b417ad3bf03/pillow_avif_plugin-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:68a79c18ac12dfee00397d749629f1beec0d7a7bff836e410301ab53c10e685a", size = 3817398 },
+    { url = "https://files.pythonhosted.org/packages/3d/f0/18dbfb4f1588752a1278ce319fcbe05401c5f661478d8542469bdd113a69/pillow_avif_plugin-1.5.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f91f8771393653d71df487022c092cb62149a3b52caea2fc6f56ebd341bc3042", size = 4045178 },
+    { url = "https://files.pythonhosted.org/packages/e2/5b/01397669a3b125c275c96f6772f105566d3e973ed7599d51097e3ad1bc8f/pillow_avif_plugin-1.5.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d3f7d124f6bc1c63608e11c7846b07357f38c3819eddb0d24476992a1cbfee07", size = 7686758 },
+    { url = "https://files.pythonhosted.org/packages/c9/4d/5fc6f93f7e220d44a733797d7cf47c3d4cef124658377dcc12a678b4cafa/pillow_avif_plugin-1.5.5-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9a1f9048de29827280630d879e184ef07424d92afe9c6b37f4c1d82670a2a00f", size = 4059287 },
+    { url = "https://files.pythonhosted.org/packages/85/49/113580ba3d53d5c60afbe763221421baa15deb2c60ef5986d1021bde46a3/pillow_avif_plugin-1.5.5-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:639d38d29f43c39141005693e850d08238dc5b7090e0a933990f52800688b0d7", size = 5511974 },
+    { url = "https://files.pythonhosted.org/packages/a4/63/dab3f2099694f73c7af3209b024658c4485cc92d71b1c207f4b09906b151/pillow_avif_plugin-1.5.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5b505c34d8e1da3bb80ff5a386f6b193ca5f9275515047ad3c7d473ab28de6cb", size = 4378927 },
+    { url = "https://files.pythonhosted.org/packages/7f/8d/b20ee173103aed1c24debf27aeb0c7e6de2c2577938e7223e42f10d82987/pillow_avif_plugin-1.5.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9df42d4b81e8d3d367d392305f45282cfc17d523348e3b38ba79744caf6bd5b", size = 5759296 },
+    { url = "https://files.pythonhosted.org/packages/4b/14/35c09b21d371c5acad848568d87a66a2c3a4953c42d233d76f98e601ef28/pillow_avif_plugin-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:a9e9d630c43773ccb3300310b97985c26117679ec5d8c9645f458538280a51a1", size = 9885322 },
+    { url = "https://files.pythonhosted.org/packages/53/ad/3f921cbde96b98db8f4300b02df97ee292bc4b2d03b6e12d21a6bbf8aaca/pillow_avif_plugin-1.5.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e69411edfcd17907038c00a46c7e2ebc2c10f14895e23a853909c34ee66ffbda", size = 5097767 },
+    { url = "https://files.pythonhosted.org/packages/92/c6/483a8a5f4a5258a685821a055a6e0e839b7d326fe3667d1d9d4e98480c13/pillow_avif_plugin-1.5.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2252182b406327dfb94e0406f8d0b5f45b4eb921e42f1574555d094359f47f86", size = 3817683 },
+    { url = "https://files.pythonhosted.org/packages/25/88/2d649aa184ef4bfa35ca83dc85b301c3d620d41641f7a2746ae97a253c0d/pillow_avif_plugin-1.5.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3c2c7ffff57675240ca0aed8f3050bc58409f8656274a1caa24d41157b98ba3b", size = 4045137 },
+    { url = "https://files.pythonhosted.org/packages/94/74/5b6f8552c882816d7d972a1a68764042b2ec48a932b31b05ed3129180738/pillow_avif_plugin-1.5.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:865902db0b4008bdd78004bb69aab796b1101e04e6175a83577042037485bf85", size = 7687054 },
+    { url = "https://files.pythonhosted.org/packages/f4/f9/23f2b8624832b0cea8fee96395d8d68e4c197b544270bdbbec560d43d416/pillow_avif_plugin-1.5.5-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1d3d48e5d3468be246fdff58e711ad0dcba5c7d6730006bab8b9c53d7dc4bddf", size = 4059366 },
+    { url = "https://files.pythonhosted.org/packages/35/9e/390200bf6f9b25398584dfcb70c20c0e8880f6d3f1648c6b9849effcfad5/pillow_avif_plugin-1.5.5-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a7bafcc8579f1ab1e8ec3f9d249528399fa50c563381e52bcf56dba797b957a3", size = 5512170 },
+    { url = "https://files.pythonhosted.org/packages/25/18/5363bd9e00dfdd6ed1153330d90d5875934446001d14e8713fcec3d94a32/pillow_avif_plugin-1.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:905b57c6b4ea323cf6731b8f8ee0d4bcc01847612c80b5fde8f9240cf3d06c75", size = 4378889 },
+    { url = "https://files.pythonhosted.org/packages/70/ec/d5d51021418ecad8650dc251bcec59db71258dec3fecd8224d515bea30ee/pillow_avif_plugin-1.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9893395d7fe2f46b500b4c2766df4721a569bfb9fd7a2e79658ab71e9c56847b", size = 5759464 },
+    { url = "https://files.pythonhosted.org/packages/ec/82/b8545508013d571c2aa2e1b0093c0b8313e250495a6a7312d623dfe427e2/pillow_avif_plugin-1.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:f3bffa2f01b3bac6cfebc47a1977344f1ab1400aaa78af437ab73ff1a6f865b4", size = 9874912 },
+    { url = "https://files.pythonhosted.org/packages/0a/07/5c8ad716fe103b66db85d756e635985084ea2965484374dc9d8fec6153d7/pillow_avif_plugin-1.5.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dc277004ea675f629ac51155275f69bb18b0b7bf3ed46a788fc4a70f79b8e2bf", size = 5097763 },
+    { url = "https://files.pythonhosted.org/packages/da/6d/b7e9573440fed7a0c1f8861f72ae74718d873c49517e79ccc623ba9a0944/pillow_avif_plugin-1.5.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5735b1373faaa890a77b91971afcc60b14cbeab3960630a76011ebdb3e6d5fe6", size = 3817677 },
+    { url = "https://files.pythonhosted.org/packages/ca/1b/b2ee574f3a873971bbe6ee6c3733200af994eff61f3eed84ea8066642d9e/pillow_avif_plugin-1.5.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0a569a81287d141b6d3b8652663eac18403dfcc1662bb2e9f8f11afa3b956d13", size = 4045056 },
+    { url = "https://files.pythonhosted.org/packages/87/c2/3c16f3741a2ecf397af314035e49e9199d14381013ff2679f283ab79e9f4/pillow_avif_plugin-1.5.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25b843855bd7f51d64def876d570836432576ccb10926744cef6e7b2bf851bea", size = 7686972 },
+    { url = "https://files.pythonhosted.org/packages/2e/c3/67716bc829df33ea5e6384d067b00a5ec9a5f50f1e53dd0af7e973236f0c/pillow_avif_plugin-1.5.5-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e60851ea25d0674650416c915377078120f078714b708aa40492765768f7595e", size = 4059374 },
+    { url = "https://files.pythonhosted.org/packages/34/86/e6ad9a25a63e6cfcdd4d4fe5600a64e94468c8ee85b2946fae95437c9348/pillow_avif_plugin-1.5.5-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b4012226dcac34f4e4ed35ed367463f8565e5f67982a9d375a39a9c377265707", size = 5512185 },
+    { url = "https://files.pythonhosted.org/packages/93/6e/d44826e765bc36c42fa30e94a4fdfc060ee0cd0aa832ee53ad72e45fdc2b/pillow_avif_plugin-1.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:41f91f044c34adf7b22e0e39fcdc5281df8894d1d694da09f4fc1551d2699dc2", size = 4378888 },
+    { url = "https://files.pythonhosted.org/packages/a7/2e/8b26a17fd308ac77bba4a044e86d16e00db2d89e776f8533f06b9517d5ea/pillow_avif_plugin-1.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e7bd1199004c61e820ef6d6bf21ab2bf76d6daea7893fe8fb06f2ddc146dfe48", size = 5759472 },
+    { url = "https://files.pythonhosted.org/packages/87/07/d432621fabce0c1eea7b92cf47186961a1c9605d7a23c0f54d25b35822c7/pillow_avif_plugin-1.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:1831d3d75671e1c0a936ffceb98bc9fb52972088de7e4f7ec8ffb4478e241f62", size = 9869801 },
+    { url = "https://files.pythonhosted.org/packages/36/db/4e59f0982986fad0c58528c984f05c5ca06000d4d5fb356235a80cec5bbb/pillow_avif_plugin-1.5.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c98ce14366b5f55272b44de22886e1d398ce33448536d0fd31224665291f8e13", size = 5098135 },
+    { url = "https://files.pythonhosted.org/packages/76/a5/15c48491809a3b94445474c9ffcfaca1a84a34219c2c68da6449c964eed0/pillow_avif_plugin-1.5.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bbd18def950386cab6383054d8858b73fc239ddfe8a5c54ca9cefbe07760fb60", size = 3818033 },
+    { url = "https://files.pythonhosted.org/packages/b8/e5/cd3cde9f10e831e4239119c8ecb733ad614ea6096e708742edf09bf1ad21/pillow_avif_plugin-1.5.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b7b596ccb0be5289ab320be6b5dc777b2c09b0ede07cc353735232cc4c73f428", size = 4050123 },
+    { url = "https://files.pythonhosted.org/packages/0a/a4/653b81ff69e9225c117e009a07d0f0fed6195c51d4aa1950c94d2b25085f/pillow_avif_plugin-1.5.5-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:787027f3cbb821627c36398b2a6c4b4c97de500e8ba966203de58e4e17943693", size = 7691199 },
+    { url = "https://files.pythonhosted.org/packages/80/c9/0f64fedd3573e9486956a9f68473a5d2d7be1040568ff8e91ceaa64b2b8d/pillow_avif_plugin-1.5.5-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c0abc4b7406d23c386bfeda9620e4c9bd54b65ccb85b42dba82c6b08aedf99d7", size = 4064545 },
+    { url = "https://files.pythonhosted.org/packages/5c/60/7541e9771fefeade486c4527b65d5beac7aeda48a6e4f99b73451e3f02fa/pillow_avif_plugin-1.5.5-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:aa82bb5f0080ae6827b4cd0a93c906cb77c0958431ed73e3b12b1f8d1ed66d0a", size = 5516645 },
+    { url = "https://files.pythonhosted.org/packages/2a/3f/04e4bd7ab8ece4f61098140c11960af0cea5b00e7b1ceb9a7f4306de050b/pillow_avif_plugin-1.5.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fe3d66eceae96094b39b3b5d7643d310ce59680f2138da59742582054830c882", size = 4383725 },
+    { url = "https://files.pythonhosted.org/packages/b0/00/43e50f35876afe5e183685528472a85ce1d7a40972f9eb0c820a3bc7b74b/pillow_avif_plugin-1.5.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6e98edb1ce487898668c93599fbb004fab68ad9d48cef11dab3675c5960fef95", size = 5763593 },
+    { url = "https://files.pythonhosted.org/packages/73/b6/7de1618fe560378874ac63c6297e45856c7541098ddc6580336f83b49f78/pillow_avif_plugin-1.5.5-cp313-cp313t-win_amd64.whl", hash = "sha256:5e2d39f9c4400e810c951b3d1d4310142fb3af43134a07c995ab1f7275b82b5e", size = 9870375 },
+    { url = "https://files.pythonhosted.org/packages/c1/d2/abe74424802cbdbe3fda1aa3aa251c6863a8f8e16c481737b1f885cd21a0/pillow_avif_plugin-1.5.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6c39a5abe3316551329c998ea14b24034f0e8a150c10b590121367a807e47c5e", size = 5097835 },
+    { url = "https://files.pythonhosted.org/packages/b8/f5/1bd31217ecf533f874a2767caa67534371bb22b716d94dd5e888dddac6af/pillow_avif_plugin-1.5.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2026acc9697b64adaa328b7e8504b579d30e45f46656953a8421aafa7b6f9b33", size = 3817665 },
+    { url = "https://files.pythonhosted.org/packages/85/f2/5af680b42114a0a361df37c828ba9455e2699084b4a074bf89bf1005909c/pillow_avif_plugin-1.5.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7524b9d0757a1ff4ed1337188d690b68949e3f521e02246b1469d49449294080", size = 4045282 },
+    { url = "https://files.pythonhosted.org/packages/d6/10/4bacc223306fad6b8823f15d0561ef6e267653a3015c7806e1d2a3c2a858/pillow_avif_plugin-1.5.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:705ddd136f03b681f5be28e72798204c957658c240d2a874d8656efecdf82b75", size = 7687078 },
+    { url = "https://files.pythonhosted.org/packages/13/f2/797f0631f21b5fab96b18479f1398cc3e177cfde5b97ffc76d4f07aa4953/pillow_avif_plugin-1.5.5-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7d3e56a596421a3af7970cf1a64767dc9fc76dc7b364b36919eb75b8b5ec5fcd", size = 4059618 },
+    { url = "https://files.pythonhosted.org/packages/d2/5a/f67fd5cae4e51173c51483f84b878af336556d14e7c6e71421341c687782/pillow_avif_plugin-1.5.5-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:0ac4ce64b66b0b6eb96484b6a9985d06f56a4b57f357f6cd1d040543f6bedf1a", size = 5512333 },
+    { url = "https://files.pythonhosted.org/packages/1a/07/dc7e99b5fb893e3fefebce79cc3c523b05c4f57f2f559e5763898af0f3f1/pillow_avif_plugin-1.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f102dec7f482b5ca999a923933e440a82bfd8ae2eb5893fe144ef8f47cf8d971", size = 4379122 },
+    { url = "https://files.pythonhosted.org/packages/3f/6f/8e0787885be7624e6b2b7abf271587ea31e8a7afb52ce2c279b98581ec67/pillow_avif_plugin-1.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e45fbda332affe999c250de21f4aca277b3fe6805c8fce182006e854e6b4de5c", size = 5759628 },
+    { url = "https://files.pythonhosted.org/packages/a8/59/f7829c6683b310308a9bae037293b5ca5844de91a93e4744996cafe74b29/pillow_avif_plugin-1.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:a6c6c70dc227d2810ae1e51e39e6f1adccd310a284e1f788aeb54a52fb95c05b", size = 9959135 },
+    { url = "https://files.pythonhosted.org/packages/9b/7d/b4b1332cd8108f9f4c171506d582f083e6df2631923976bf768dc81b5a17/pillow_avif_plugin-1.5.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:cff2d641b86a72c6767f19f0c5fdab54289d1fa9457bcacb19c030b620ca461e", size = 5098234 },
+    { url = "https://files.pythonhosted.org/packages/27/54/029a29d04e6269bdb25171d1646b23c1e2dad15c84fe5c0398c76790113c/pillow_avif_plugin-1.5.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cf462e4f1463a942a77f7222b8bc4d51f0580aed49cedb36c7cfe35028a9f67b", size = 3818041 },
+    { url = "https://files.pythonhosted.org/packages/49/97/69fdcfe81628a1a636d92e779fc27a8bb84f036996f504090f03ca927424/pillow_avif_plugin-1.5.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d410c8f7a8f570f93cbbeffcde22574cbf57bc8e5de8ccc973530a74f1aaeee2", size = 4050268 },
+    { url = "https://files.pythonhosted.org/packages/27/b7/42d45dade43b08d6656982b57abef929a1af82ffe1c794128734dbb670fe/pillow_avif_plugin-1.5.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73d37914ad82bec6583c5df70dea5ccb4d2f5435ca3c48e50b1c5fff52c92d6e", size = 7691352 },
+    { url = "https://files.pythonhosted.org/packages/13/28/359ff8ea591f374170949392ec20b91de1bf1149e9cc9a8d060b7bb077e8/pillow_avif_plugin-1.5.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:9441006c3d242dfb7b54e9294a747b578f620446998a2384cfd2926cc0c0d107", size = 4064664 },
+    { url = "https://files.pythonhosted.org/packages/f3/08/c8abcff61c73e3c199fd19766b792c48bc41c35cab670c9e7ea6a4c207c4/pillow_avif_plugin-1.5.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:465f2aa24ed03d4ad5545ab4cd7627074c181cc0e96715419cd6c8fcff509779", size = 5516782 },
+    { url = "https://files.pythonhosted.org/packages/5f/24/7b6f75a48d2c2b8461b461bad834b2294277040f643a09ba7ce446a603f8/pillow_avif_plugin-1.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0b04eac3d9f13f3fb1f147dbc39a54c186d16b8696b2b984880d01803995dbd5", size = 4383836 },
+    { url = "https://files.pythonhosted.org/packages/8f/72/c9b4e7c2d6216d85fadde8dc3d6074d70c2734ee5627065f4ca6403cadcf/pillow_avif_plugin-1.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1bc75fe3ce1f369bb5068911625fca1430c63b62ae8d8c1ae85e4c839b4dd23c", size = 5763739 },
+    { url = "https://files.pythonhosted.org/packages/53/eb/27af95ea3db131f5ed17541c74b9a14c40bc33f68ff9a78e1696f0285565/pillow_avif_plugin-1.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:3ec51ff05f6d254b3d2ec2fd134040921959554b542a5f1dbb62ee49c29e51ed", size = 9959564 },
 ]
 
 [[package]]


### PR DESCRIPTION
…dia rendering

- Added optional dependency for `pillow-avif-plugin` in `pyproject.toml` and `uv.lock`.
- Introduced a new test class `MediaRenditionsTestCase` in `tests/test_media.py` to validate media rendition generation, deletion, and regeneration.
- Implemented helper function `_clean_renditions_dir` to manage media rendition directories during tests.
- Added tests for verifying rendition generation on upload, skipping upscaling, deletion effects, and template tag functionality.